### PR TITLE
Make stacktraces optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,5 +25,10 @@ An extra panel titled "MongoDB" should appear in your debug toolbar.
 
 Note that this should work with any Django application that uses PyMongo.
 
+Obtaining stack traces can slow down queries significantly. To turn them off
+add the following lines to your ``settings.py``::
+
+    DEBUG_TOOLBAR_MONGO_STACKTRACES = False
+
 Disclaimer: only tested in latest Chrome, may fall to pieces in other browers.
 If you feel like fixing it, contributions are welcome!

--- a/debug_toolbar_mongo/operation_tracker.py
+++ b/debug_toolbar_mongo/operation_tracker.py
@@ -28,6 +28,13 @@ inserts = []
 updates = []
 removes = []
 
+WANT_STACK_TRACE = getattr(settings, 'DEBUG_TOOLBAR_MONGO_STACKTRACES', True)
+def _get_stacktrace():
+    if WANT_STACK_TRACE:
+        return _tidy_stacktrace(reversed(inspect.stack()))
+    else:
+        return []
+
 
 # Wrap Cursor._refresh for getting queries
 @functools.wraps(_original_methods['insert'])
@@ -47,7 +54,7 @@ def _insert(collection_self, doc_or_docs, manipulate=True,
         'document': doc_or_docs,
         'safe': safe,
         'time': total_time,
-        'stack_trace': _tidy_stacktrace(reversed(inspect.stack())),
+        'stack_trace': _get_stacktrace(),
     })
     return result
 
@@ -75,7 +82,7 @@ def _update(collection_self, spec, document, upsert=False,
         'spec': spec,
         'safe': safe,
         'time': total_time,
-        'stack_trace': _tidy_stacktrace(reversed(inspect.stack())),
+        'stack_trace': _get_stacktrace(),
     })
     return result
 
@@ -96,7 +103,7 @@ def _remove(collection_self, spec_or_id, safe=False, **kwargs):
         'spec_or_id': spec_or_id,
         'safe': safe,
         'time': total_time,
-        'stack_trace': _tidy_stacktrace(reversed(inspect.stack())),
+        'stack_trace': _get_stacktrace(),
     })
     return result
 
@@ -125,7 +132,7 @@ def _cursor_refresh(cursor_self):
     query_data = {
         'time': total_time,
         'operation': 'query',
-        'stack_trace': _tidy_stacktrace(reversed(inspect.stack())),
+        'stack_trace': _get_stacktrace(),
     }
 
     # Collection in format <db_name>.<collection_name>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-debug-toolbar-mongo',
-    version='0.1.2',
+    version='0.1.3',
     description='MongoDB panel for the Django Debug Toolbar',
     long_description=open('README.rst').read(),
     author='Harry Marr',


### PR DESCRIPTION
Obtaining stack traces can increase the impact of a single query from 0.5ms to 10ms. This means that a page with a load of small and quick queries makes a page take ages whilst the toolbar is in use. It also makes it harder to find where the slow points actually are.

So, make them optional!
