### PR TITLE
Workaround for inspect.stack() failing when jinja2 templates are on the stack

### DIFF
--- a/debug_toolbar_mongo/operation_tracker.py
+++ b/debug_toolbar_mongo/operation_tracker.py
@@ -36,7 +36,13 @@ def _get_stacktrace():
         except IndexError:
             # this is a work around because python's inspect.stack() sometimes fail
             # when jinja templates are on the stack
-            return []
+            return [(
+                "",
+                0,
+                "Error retrieving stack",
+                "Could not retrieve stack. IndexError exception occured in inspect.stack(). "
+                "This error might occur when jinja2 templates is on the stack.",
+            )]
         
         return _tidy_stacktrace(reversed(stack))
     else:


### PR DESCRIPTION
When jinja2 templates are on the stack, inspect.stack() often fails with IndexError (because the generated python code usually have more lines than the template file. Here's the issue in the jinja2 repo: https://github.com/mitsuhiko/jinja2/issues/38

This is a work around that explicitly checks for this exception, and replaces the stack trace with a message saying that the stack could not be retrieved. 

Preferably, this should of course be fixed in jinja2, but the issue has been open for a long time, and since using jinja2 with Django is a common use case, I think including a workaround in django-debug-toolbar-mongo is justified.
