### PR TITLE
Updated setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+.tox
+*.egg-info
+*.egg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.rst
+include debug_toolbar_mongo/templates/*

--- a/debug_toolbar_mongo/__init__.py
+++ b/debug_toolbar_mongo/__init__.py
@@ -1,0 +1,2 @@
+# following PEP 386, versiontools will pick it up
+__version__ = (0, 1, 4, "final", 0)

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,19 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-debug-toolbar-mongo',
-    version='0.1.4',
+    version=":versiontools:debug_toolbar_mongo:",
     description='MongoDB panel for the Django Debug Toolbar',
     long_description=open('README.rst').read(),
     author='Harry Marr',
     author_email='harry@hmarr.com',
     url='https://github.com/hmarr/django-debug-toolbar-mongo',
     license='MIT',
-    packages=['debug_toolbar_mongo'],
-    package_data={ 'debug_toolbar_mongo': ['templates/*', 'templatetags/*'] },
+    packages=find_packages(exclude=('example', )),
     include_package_data=True,
+    zip_safe=False,
+    setup_requires=[
+        'versiontools >= 1.6',
+    ],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[tox]
+setupdir = .


### PR DESCRIPTION
I had some problems installing this package, so 
made some changes to the setup.py.

The template files and templatetags dir should now
be included as expected. I also added tox to test
the setup.py and versiontools to pull the version
from the init.
