### PR TITLE
don't use self.__class__ with super()

### DIFF
--- a/debug_toolbar_mongo/panel.py
+++ b/debug_toolbar_mongo/panel.py
@@ -12,7 +12,7 @@ class MongoDebugPanel(DebugPanel):
     has_content = True
 
     def __init__(self, *args, **kwargs):
-        super(self.__class__, self).__init__(*args, **kwargs)
+        super(MongoDebugPanel, self).__init__(*args, **kwargs)
         operation_tracker.install_tracker()
 
     def process_request(self, request):


### PR DESCRIPTION
I also thought this was clever, but I was wrong... oh so wrong...

[deadwisdom from reddit says](http://www.reddit.com/r/Python/comments/977eo/protip_stop_hardcoding_the_class_name_when_using/c0bo068):

> Don't do this... It doesn't work:
> 
> ```
> class A(object):
>     def hello(self):
>         return "Hello World!"
> 
> class B(A):
>     def hello(self):
>         return super(self.__class__, self).hello()
> 
> b = B()
> assert b.hello() == "Hello World!"
> ```
> 
> Okay, works fine here, but...
> 
> ```
> class C(B):
>     def hello(self):
>         return super(self.__class__, self).hello()
> 
> c = C()
> assert c.hello() == "Hello World!"
> ```
> 
> RuntimeError: maximum recursion depth exceeded
> 
> When it gets to B's hello, it supers c's class, C, which is B... This is precisely the sort of bug that will eat you when you least expect it.
