### PR TITLE
Improvements on the MongoDB panel

### DIFF
--- a/debug_toolbar_mongo/operation_tracker.py
+++ b/debug_toolbar_mongo/operation_tracker.py
@@ -145,7 +145,7 @@ def _cursor_refresh(cursor_self):
     __traceback_hide__ = True
     query_data = {
         'time': total_time,
-        'operation': 'query',
+        'operation': 'find',
         'stack_trace': _get_stacktrace(),
     }
 
@@ -161,7 +161,7 @@ def _cursor_refresh(cursor_self):
             query_data['collection'] = query_son['count']
             query_data['operation'] = 'count'
             query_data['skip'] = query_son.get('skip')
-            query_data['limit'] = query_son.get('limit')
+            query_data['limit'] = abs(query_son.get('limit', 0))
             query_data['query'] = query_son['query']
         elif 'aggregate' in query_son:
             query_data['collection'] = query_son['aggregate']
@@ -172,7 +172,7 @@ def _cursor_refresh(cursor_self):
     else:
         # Normal Query
         query_data['skip'] = privar('skip')
-        query_data['limit'] = privar('limit')
+        query_data['limit'] = abs(privar('limit') or 0)
         query_data['query'] = query_son.get('$query') or query_son
         query_data['ordering'] = _get_ordering(query_son)
 

--- a/debug_toolbar_mongo/panel.py
+++ b/debug_toolbar_mongo/panel.py
@@ -1,9 +1,20 @@
+from django.template import Template, Context
 from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
 
 from debug_toolbar.panels import DebugPanel
 
 import operation_tracker
 
+_NAV_SUBTITLE_TPL = u'''
+{% for o, n, t in operations %}
+    {{ n }} {{ o }}{{ n|pluralize }} in {{ t }}ms<br/>
+
+    {% if forloop.last and forloop.counter0 %}
+        {{ count }} operation{{ count|pluralize }} in {{ time }}ms
+    {% endif %}
+{% endfor %}
+'''
 
 class MongoDebugPanel(DebugPanel):
     """Panel that shows information about MongoDB operations.
@@ -22,11 +33,32 @@ class MongoDebugPanel(DebugPanel):
         return 'MongoDB'
 
     def nav_subtitle(self):
-        num_queries = len(operation_tracker.queries)
-        attrs = ['queries', 'inserts', 'updates', 'removes']
-        total_time = sum(sum(o['time'] for o in getattr(operation_tracker, a))
-                         for a in attrs)
-        return '{0} operations in {1:.2f}ms'.format(num_queries, total_time)
+        fun = lambda x, y: (x, len(y), '%.2f' % sum(z['time'] for z in y))
+        ctx = {'operations': [], 'count': 0, 'time': 0}
+
+        if operation_tracker.queries:
+            ctx['operations'].append(fun('read', operation_tracker.queries))
+            ctx['count'] += len(operation_tracker.queries)
+            ctx['time'] += sum(x['time'] for x in operation_tracker.queries)
+
+        if operation_tracker.inserts:
+            ctx['operations'].append(fun('insert', operation_tracker.inserts))
+            ctx['count'] += len(operation_tracker.inserts)
+            ctx['time'] += sum(x['time'] for x in operation_tracker.inserts)
+
+        if operation_tracker.updates:
+            ctx['operations'].append(fun('update', operation_tracker.updates))
+            ctx['count'] += len(operation_tracker.updates)
+            ctx['time'] += sum(x['time'] for x in operation_tracker.updates)
+
+        if operation_tracker.removes:
+            ctx['operations'].append(fun('remove', operation_tracker.removes))
+            ctx['count'] += len(operation_tracker.removes)
+            ctx['time'] += sum(x['time'] for x in operation_tracker.removes)
+
+        ctx['time'] = '%.2f' % ctx['time']
+
+        return mark_safe(Template(_NAV_SUBTITLE_TPL).render(Context(ctx)))
 
     def title(self):
         return 'MongoDB Operations'

--- a/debug_toolbar_mongo/templates/mongo-panel.html
+++ b/debug_toolbar_mongo/templates/mongo-panel.html
@@ -1,6 +1,18 @@
 {% load mongo_debug_tags %}
 
 <style type="text/css">
+#djDebug .panelContent tbody th {
+    width: auto;
+}
+#djDebug .panelContent table {
+    display: table;
+}
+#djDebug tr.row1 {
+    background-color: #F5F5F5;
+}
+#djDebug #djDebugRequestVarsPanel table:first-of-type tbody tr:nth-child(odd) {
+    background-color: #F5F5F5;
+}
 pre.mongo-highlight, pre.mongo-highlight span {
     font-family: 'Consolas', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', 'Monaco', 'Courier New', monospace !important;
     font-size: 1.05em !important;
@@ -19,7 +31,7 @@ table.mongo-op-table tbody {
 }
 </style>
 
-<h4>Queries</h4>
+<h4>Reads</h4>
 {% if queries %}
 <table class="mongo-op-table">
     <thead>
@@ -27,7 +39,7 @@ table.mongo-op-table tbody {
             <th>Time (ms)</th>
             <th>Operation</th>
             <th>Collection</th>
-            <th>Query</th>
+            <th style="width: 100%">Query</th>
             <th>Ordering</th>
             <th>Skip</th>
             <th>Limit</th>
@@ -42,12 +54,12 @@ table.mongo-op-table tbody {
                 <td>{{ query.collection }}</td>
                 <td>
                     {% if query.query %}
-                    <pre class="mongo-highlight">{{ query.query|format_dict|highlight:"javascript"|safe }}</pre>
-                  {% endif %}
+                        <pre class="mongo-highlight">{{ query.query|format_dict|highlight:"javascript"|safe }}</pre>
+                    {% endif %}
                 </td>
-                <td><pre class="mongo-highlight">{% if query.ordering %}{{ query.ordering }}{% endif %}</pre></td>
-                <td>{% if query.skip %}{{ query.skip }}{% endif %}</td>
-                <td>{% if query.limit %}{{ query.limit }}{% endif %}</td>
+                <td>{% if query.ordering %}<pre class="mongo-highlight">{{ query.ordering }}</pre>{% endif %}</td>
+                <td>{{ query.skip|default:"" }}</td>
+                <td>{{ query.limit|default:"" }}</td>
                 <td><a href="javascript:void(0);" class="mongo-toggle-trace" data-row="queries-{{ forloop.counter }}">Toggle</a></td>
             </tr>
             <tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}">
@@ -87,7 +99,7 @@ table.mongo-op-table tbody {
     <thead>
         <tr>
             <th>Time (ms)</th>
-            <th>Document</th>
+            <th style="width: 100%">Document</th>
             <th>Safe</th>
             <th>Stack Trace</th>
         </tr>
@@ -133,58 +145,6 @@ table.mongo-op-table tbody {
 <p>No inserts recorded</p>
 {% endif %}
 
-<h4>Removes</h4>
-{% if removes %}
-<table class="mongo-op-table">
-    <thead>
-        <tr>
-            <th>Time (ms)</th>
-            <th>Query / Id</th>
-            <th>Safe</th>
-            <th>Stack Trace</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for remove in removes %}
-            <tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}">
-                <td>{{ remove.time|floatformat:"4" }}</td>
-                <td>
-                    <pre class="mongo-highlight">{{ remove.spec_or_id|format_dict:120|highlight:"javascript"|safe }}</pre>
-                </td>
-                <td>{{ remove.safe }}</td>
-                <td><a href="javascript:void(0);" class="mongo-toggle-trace" data-row="removes-{{ forloop.counter }}">Toggle</a></td>
-            </tr>
-            <tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}">
-                <td colspan="4">
-                    <table class="mongo-stack-trace "id="mongo-stack-trace-removes-{{ forloop.counter }}">
-                        <thead>
-                            <tr>
-                                <th>Line</th>
-                                <th>File</th>
-                                <th>Function</th>
-                                <th>Code</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for line in remove.stack_trace %}
-                            <tr>
-                                <td class="lineno">{{ line.1 }}</td>
-                                <td class="file">{{ line.0|embolden_file }}</td>
-                                <td class="function">{{ line.2 }}</td>
-                                <td class="code">{{ line.3|highlight:"python"|safe }}</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        {% endfor %}
-    </tbody>
-</table>
-{% else %}
-<p>No removes recorded</p>
-{% endif %}
-
 <h4>Updates</h4>
 {% if updates %}
 <table class="mongo-op-table">
@@ -192,7 +152,7 @@ table.mongo-op-table tbody {
         <tr>
             <th>Time (ms)</th>
             <th>Query</th>
-            <th>Update</th>
+            <th style="width: 100%">Update</th>
             <th>Safe</th>
             <th>Multi</th>
             <th>Upsert</th>
@@ -243,6 +203,58 @@ table.mongo-op-table tbody {
 </table>
 {% else %}
 <p>No updates recorded</p>
+{% endif %}
+
+<h4>Removes</h4>
+{% if removes %}
+<table class="mongo-op-table">
+    <thead>
+        <tr>
+            <th>Time (ms)</th>
+            <th style="width: 100%">Query / Id</th>
+            <th>Safe</th>
+            <th>Stack Trace</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for remove in removes %}
+            <tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}">
+                <td>{{ remove.time|floatformat:"4" }}</td>
+                <td>
+                    <pre class="mongo-highlight">{{ remove.spec_or_id|format_dict:120|highlight:"javascript"|safe }}</pre>
+                </td>
+                <td>{{ remove.safe }}</td>
+                <td><a href="javascript:void(0);" class="mongo-toggle-trace" data-row="removes-{{ forloop.counter }}">Toggle</a></td>
+            </tr>
+            <tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}">
+                <td colspan="4">
+                    <table class="mongo-stack-trace "id="mongo-stack-trace-removes-{{ forloop.counter }}">
+                        <thead>
+                            <tr>
+                                <th>Line</th>
+                                <th>File</th>
+                                <th>Function</th>
+                                <th>Code</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for line in remove.stack_trace %}
+                            <tr>
+                                <td class="lineno">{{ line.1 }}</td>
+                                <td class="file">{{ line.0|embolden_file }}</td>
+                                <td class="function">{{ line.2 }}</td>
+                                <td class="code">{{ line.3|highlight:"python"|safe }}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>No removes recorded</p>
 {% endif %}
 
 <script>


### PR DESCRIPTION
Hi, I've made a few improvements to the interface of the MongoDB panel. Below some screenshots and commit message. Hope you enjoy.

---

Sidebar:

![sidebar](https://f.cloud.github.com/assets/1233439/165263/1fb92470-7930-11e2-9eba-b0b8c1e320b7.png)

Stack trace:

![stack_trace](https://f.cloud.github.com/assets/1233439/165264/2272b10e-7930-11e2-89c3-2ec33a7c7bde.png)

---

The sidebar now shows the count and time elapsed for each type of
operation performed: read, insert, update, remove.

Changed some code to better reflect MongoDB terminology. The default
operation is now find, instead of query. Queries table became the Reads
table since it displays finds, counts, commands etc. Also, query is
mostly a relational database term.

Corrected the layout of tables, which now properly occupy 100% width of
their containers.
