### PR TITLE
django-debug-toolbar==1.0 support

### DIFF
--- a/debug_toolbar_mongo/panel.py
+++ b/debug_toolbar_mongo/panel.py
@@ -21,6 +21,7 @@ class MongoDebugPanel(DebugPanel):
     """
     name = 'MongoDB'
     has_content = True
+    template = 'mongo-panel.html'
 
     def __init__(self, *args, **kwargs):
         super(MongoDebugPanel, self).__init__(*args, **kwargs)
@@ -66,12 +67,10 @@ class MongoDebugPanel(DebugPanel):
     def url(self):
         return ''
 
-    def content(self):
-        context = self.context.copy()
-        context['queries'] = operation_tracker.queries
-        context['inserts'] = operation_tracker.inserts
-        context['updates'] = operation_tracker.updates
-        context['removes'] = operation_tracker.removes
-        return render_to_string('mongo-panel.html', context)
-
-
+    def process_response(self, request, response):
+        self.record_stats({
+            'queries': operation_tracker.queries,
+            'inserts': operation_tracker.inserts,
+            'updates': operation_tracker.updates,
+            'removes': operation_tracker.removes
+        })


### PR DESCRIPTION
This will probably break compatibility with older versions of django-debug-toolbar but it allows me to use this panel with latest django-debug-toolbar
