### PR TITLE
Updated to use latest version of the debug-toolbar library. 

### DIFF
--- a/debug_toolbar_mongo/operation_tracker.py
+++ b/debug_toolbar_mongo/operation_tracker.py
@@ -28,6 +28,8 @@ updates = []
 removes = []
 
 WANT_STACK_TRACE = getattr(settings, 'DEBUG_TOOLBAR_MONGO_STACKTRACES', True)
+
+
 def _get_stacktrace():
     if WANT_STACK_TRACE:
         try:

--- a/debug_toolbar_mongo/panel.py
+++ b/debug_toolbar_mongo/panel.py
@@ -1,8 +1,7 @@
 from django.template import Template, Context
-from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 
-from debug_toolbar.panels import DebugPanel
+from debug_toolbar.panels import Panel
 
 import operation_tracker
 
@@ -16,11 +15,13 @@ _NAV_SUBTITLE_TPL = u'''
 {% endfor %}
 '''
 
-class MongoDebugPanel(DebugPanel):
+
+class MongoDebugPanel(Panel):
     """Panel that shows information about MongoDB operations.
     """
     name = 'MongoDB'
     has_content = True
+    template = 'mongo-panel.html'
 
     def __init__(self, *args, **kwargs):
         super(MongoDebugPanel, self).__init__(*args, **kwargs)
@@ -66,12 +67,14 @@ class MongoDebugPanel(DebugPanel):
     def url(self):
         return ''
 
-    def content(self):
-        context = self.context.copy()
-        context['queries'] = operation_tracker.queries
-        context['inserts'] = operation_tracker.inserts
-        context['updates'] = operation_tracker.updates
-        context['removes'] = operation_tracker.removes
-        return render_to_string('mongo-panel.html', context)
+    def get_stats(self):
+
+        return {
+            'queries': operation_tracker.queries,
+            'inserts': operation_tracker.inserts,
+            'updates': operation_tracker.updates,
+            'removes': operation_tracker.removes
+        }
+
 
 


### PR DESCRIPTION
Now inherits from Panel rather than the DebugPanel. 

Replaced the content method with a template property and get_stats() method so that it utilises the underlying content() method call.
