### PR TITLE
Adding suppport for Django2.0/Python3.6

### DIFF
--- a/debug_toolbar_mongo/operation_tracker.py
+++ b/debug_toolbar_mongo/operation_tracker.py
@@ -2,8 +2,11 @@ import functools
 import time
 import inspect
 import os
-import SocketServer
-
+try:
+    import SocketServer
+except:
+    import socketserver
+           
 import django
 from django.conf import settings
 

--- a/debug_toolbar_mongo/panel.py
+++ b/debug_toolbar_mongo/panel.py
@@ -4,8 +4,11 @@ from django.utils.safestring import mark_safe
 
 from debug_toolbar.panels import DebugPanel
 
-import operation_tracker
-
+try:
+    import operation_tracker
+except:
+    from . import operation_tracker
+    
 _NAV_SUBTITLE_TPL = u'''
 {% for o, n, t in operations %}
     {{ n }} {{ o }}{{ n|pluralize }} in {{ t }}ms<br/>


### PR DESCRIPTION
I am using Django2.0 and djongo library https://github.com/nesdis/djongo

I installed django-debug-toolbar-mongo and it failed on import statements.

I made these 2 changes locally in my project and it worked.
